### PR TITLE
fix importing of libs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/ds-test"]
 	path = lib/ds-test
 	url = https://github.com/dapphub/ds-test
+[submodule "lib/openzeppelin-contracts"]
+	path = lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/src/ERC721WithOnMintGeneration.sol
+++ b/src/ERC721WithOnMintGeneration.sol
@@ -2,7 +2,7 @@
 pragma solidity >0.8.0;
 
 import "./tokens/ERC721.sol";
-import "@openzeppelin/contracts/utils/Strings.sol";
+import "openzeppelin-contracts/utils/Strings.sol";
 
 import { OnMintGeneration } from "./OnMintGeneration.sol";
 


### PR DESCRIPTION
Hello, tried running the repo but OZ library was missing. This PR adds the lib so people can clone, run `forge update` and play with it.